### PR TITLE
Enable strict mode in webpack.config.js to be able to use let

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+"use strict";
 let path = require("path")
 let fs = require("fs")
 


### PR DESCRIPTION
This fixes the following error:

```
❯ npm run build


> cell-viz@1.1.2 build /Users/lukas/Jobs/Bachelorarbeit/cell-viz
> webpack

/Users/lukas/Jobs/Bachelorarbeit/cell-viz/webpack.config.js:1
(function (exports, require, module, __filename, __dirname) { let path = require("path")
                                                              ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at module.exports (/Users/lukas/Jobs/Bachelorarbeit/cell-viz/node_modules/webpack/bin/convert-argv.js:80:13)
    at Object.<anonymous> (/Users/lukas/Jobs/Bachelorarbeit/cell-viz/node_modules/webpack/bin/webpack.js:39:40)
    at Module._compile (module.js:409:26)
```